### PR TITLE
fix semver-select error

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,6 +55,23 @@ jobs:
           [[ "$(go version)" == *"1.15.5"* ]]
           [[ '${{steps.setup_go_1_15_5.outputs.GOROOT}}' == *"1.15.5"* ]]
           [[ '${{steps.setup_go_1_15_5.outputs.GOTOOLDIR}}' == *"1.15.5"* ]]
+
+
+      - id: setup_go_1_16rc1
+        name: install 1.16rc1
+        uses: ./
+        with:
+          go-version: '1.16rc1'
+      - name: outputs
+        run: |
+          echo '${{ toJson( steps.setup_go_1_16rc1.outputs ) }}' | jq .
+          go version
+          set -ex
+          [[ "$(go version)" == *"1.16rc1"* ]]
+          [[ '${{steps.setup_go_1_16rc1.outputs.GOROOT}}' == *"16rc1"* ]]
+          [[ '${{steps.setup_go_1_16rc1.outputs.GOTOOLDIR}}' == *"16rc1"* ]]
+
+
       - id: setup_go_all
         name: install '*'
         uses: ./
@@ -64,6 +81,8 @@ jobs:
         run: |
           echo '${{ toJson( steps.setup_go_all.outputs ) }}' | jq .
           go version
+
+
       - id: setup_go_1_15_5_again
         name: install 1.15.5 again
         uses: ./
@@ -77,6 +96,8 @@ jobs:
           [[ "$(go version)" == *"1.15.5"* ]]
           [[ '${{steps.setup_go_1_15_5_again.outputs.GOROOT}}' == *"1.15.5"* ]]
           [[ '${{steps.setup_go_1_15_5_again.outputs.GOTOOLDIR}}' == *"1.15.5"* ]]
+
+
       - id: setup_go_1_13_x
         name: install 1.13.x
         uses: ./

--- a/src/lib
+++ b/src/lib
@@ -134,12 +134,15 @@ select_local_version() {
   local local_versions
   local_versions="$(ls "$go_tool_cache")"
 
-  # return any exact matches first for fastest possible result
-  for v in $local_versions; do
-    if [ "$v" = "$constraint" ]; then
-      echo "$v" && return
-    fi
-  done
+  # if this is a plain version instead of a constraint, only an exact match will work
+  if is_precise_version "$constraint"; then
+    for v in $local_versions; do
+      if [ "$v" = "$constraint" ]; then
+        echo "$v" && return
+      fi
+    done
+    return
+  fi
 
   # handle the 1.x type constraint
   if ver="$(select_go_version "$constraint" "$local_versions")"; then
@@ -163,5 +166,11 @@ select_remote_version() {
   if got="$(select_go_version "$constraint" "$jq_parsed")"; then
     echo "$got" && return
   fi
+
+  # don't try semver-select on a precise version
+  if is_precise_version "$constraint"; then
+    return
+  fi
+
   echo "$jq_parsed" | ./src/semver-select -c "$GO_VERSION_CONSTRAINT" -n 1 -i -
 }

--- a/src/lib_test.sh
+++ b/src/lib_test.sh
@@ -39,6 +39,7 @@ test_is_precise_version() {
 1.1.1
 9999.9999.9999
 1.15beta1
+1.16rc1
   '
 
   for v in $versions; do


### PR DESCRIPTION
fixes #5

As reported in #5, there was an error with checking semver-select on prerelease versions.

It turns out the install will still work but the log makes is appear that it didn't. The problem is that when checking for available versions, the action was running semver-select on exact matches. In addition to this producing misleading messages it also wasted time.