### PR TITLE
register problem matcher

### DIFF
--- a/matchers.json
+++ b/matchers.json
@@ -1,0 +1,16 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "go",
+            "pattern": [
+                {
+                    "regexp": "^\\s*(.+\\.go):(?:(\\d+):(\\d+):)? (.*)",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "message": 4
+                }
+            ]
+        }
+    ]
+}

--- a/src/run
+++ b/src/run
@@ -59,4 +59,6 @@ if [ -z "$lv" ]; then
   exit 1
 fi
 
+echo "::add-matcher::$GITHUB_ACTION_PATH/matchers.json"
+
 src/install-go "$lv" "$target_dir" "$install_parent/tip/x64"


### PR DESCRIPTION
This will match compiler errors and the output of common static analysis
tools, and annotate commits with the output, so that the output will
appear inline in diffs.

All actions that execute after this action will make use of the
problem matcher.