### PR TITLE
Write unmodified path to GITHUB_PATH

### DIFF
--- a/src/lib
+++ b/src/lib
@@ -103,9 +103,6 @@ add_to_system_path() {
 
 add_to_github_path() {
   element="$1"
-  if [ "$(goos)" == "windows" ]; then
-    element="$(echo "/$element" | sed -e 's|\\|/|g' | sed 's/://')"
-  fi
   echo "$element" >>"$GITHUB_PATH"
 }
 


### PR DESCRIPTION
Modifying the path so that it suits bash breaks it for Powershell, as
well as any other non-Bash process that tries to look up executables,
because Windows has no idea what to do with a path like /c/foo.

Bash, however, already gets started with correctly converted paths and
we didn't have to do anything to support this.

Closes gh-13
Closes gh-14