### PR TITLE
Add option to specify go version from go.mod or go.work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: ci
-on: [ push, workflow_dispatch ]
+on:
+  push:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   cibuild:
     name: cibuild

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -137,3 +137,34 @@ jobs:
           [[ "$(go version)" == *"1.13"* ]]
           [[ '${{steps.setup_go_1_13_x.outputs.GOROOT}}' == *"1.13"* ]]
           [[ '${{steps.setup_go_1_13_x.outputs.GOTOOLDIR}}' == *"1.13"* ]]
+
+
+      - name: create_go_mod
+        run: |
+          cat >> go.mod << EOF
+          module example.com/some-module
+ 
+          go 1.15
+ 
+          require (
+            golang.org/x/exp v0.0.0-20230728194245-b0cb94b80691
+            golang.org/x/sync v0.3.0
+          )
+      - id: setup_go_1_15_from_go_mod
+        name: install 1.15 from go.mod
+        uses: ./
+        with:
+          go-version-file: 'go.mod'
+          ignore-local: true
+      - name: outputs
+        run: |
+          echo '*********** env ************'
+          env
+          echo '*********** go env ***********'
+          go env
+          echo '${{ toJson( steps.setup_go_1_15_from_go_mod.outputs ) }}' | jq .
+          go version
+          set -ex
+          [[ "$(go version)" == *"1.15"* ]]
+          [[ '${{steps.setup_go_1_15_from_go_mod.outputs.GOROOT}}' == *"1.15"* ]]
+          [[ '${{steps.setup_go_1_15_from_go_mod.outputs.GOTOOLDIR}}' == *"1.15"* ]]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,9 @@
 name: integration
-on: [ push, workflow_dispatch ]
+on:
+  push:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   install_go_tip:
     name: install tip

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -208,6 +208,10 @@ jobs:
           echo '${{ toJson( steps.setup_go_1_15_from_go_mod.outputs ) }}' | jq .
           go version
           set -ex
-          [[ "$(go version)" == *"1.15"* ]]
-          [[ '${{steps.setup_go_1_15_from_go_mod.outputs.GOROOT}}' == *"1.15"* ]]
-          [[ '${{steps.setup_go_1_15_from_go_mod.outputs.GOTOOLDIR}}' == *"1.15"* ]]
+          requested_min_version='1.15'
+          installed_version="$(go version | cut -d " " -f 3 | tr -d "go")"
+          lowest_version="$(echo -e "$requested_min_version\n$installed_version" | sort -rV | tail -1)"
+
+          [[ "$lowest_version" == "$requested_min_version" ]]
+          [[ '${{steps.setup_go_1_15_from_go_mod.outputs.GOROOT}}' == *"$installed_version"* ]]
+          [[ '${{steps.setup_go_1_15_from_go_mod.outputs.GOTOOLDIR}}' == *"$installed_version"* ]]

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ accordingly. If there is good use case for `stable`, it can be added.
 
 ### go-version
 
-__Required__
-
 The version of go to install. It can be an exact version or a semver constraint like '1.14.x' or '^1.14.4'.
 Do not add "go" or "v" to the beginning of the version.
 
@@ -95,6 +93,10 @@ For those who learn best from examples:
 | < 1.15.6 >= 1.15.4 | installs a go that is >= 1.15.4 and < 1.15.6                                                   |
 | tip                | installs gotip  from source                                                                    |
 
+
+### go-version-file
+
+Path to the go.mod or go.work file.
 
 ### ignore-local
 

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Setup Go Faster'
 description: It's like actions/setup-go but faster.
 inputs:
   go-version:
-    required: true
+    required: false
     description: |
       The version of go to install. It can be an exact version or a semver constraint like '1.14.x' or '^1.14.4'.
       Do not add "go" or "v" to the beginning of the version.
@@ -40,6 +40,9 @@ inputs:
       | < 1.15.6 >= 1.15.4 | installs a go that is >= 1.15.4 and < 1.15.6                                                   |
       | tip                | installs gotip  from source                                                                    |
 
+  go-version-file:
+    required: false
+    description: 'Path to the go.mod or go.work file.'
   ignore-local:
     required: false
     description: |
@@ -72,6 +75,7 @@ runs:
         DEBUG: ""
         IGNORE_LOCAL_GO: ${{ inputs.ignore-local }}
         GO_VERSION: ${{ inputs.go-version }}
+        GO_VERSION_FILE: ${{ inputs.go-version-file }}
       shell: bash
       run: src/run
 branding:

--- a/src/lib
+++ b/src/lib
@@ -181,8 +181,13 @@ select_go_version_from_file() {
   file_name="$(basename "$go_file_path")"
   if [ "$file_name" != "go.mod" ] && [ "$file_name" != "go.work" ]; then
     echo "::error ::File is not go.mod nor go.work"
-    return
+    return 1
   fi
 
-  perl -nle 'print $1 if /^go (\d\.\d+)/' < "$go_file_path"
+  found_version="$(perl -nle 'print $1 if /^\s*go (\d\.\d+.*$)/' < "$go_file_path")"
+  if [ -z "$found_version" ]; then
+    found_version="1.16"
+  fi
+
+  echo "$found_version"
 }

--- a/src/lib
+++ b/src/lib
@@ -184,7 +184,7 @@ select_go_version_from_file() {
     return 1
   fi
 
-  found_version="$(perl -nle 'print $1 if /^\s*go (\d\.\d+.*$)/' < "$go_file_path")"
+  found_version="$(perl -nle 'print $1 if /^\s*go\s+(\S+)\s*(?:$|(?:\/\/))/' < "$go_file_path")"
   if [ -z "$found_version" ]; then
     found_version="1.16"
   fi

--- a/src/lib
+++ b/src/lib
@@ -172,3 +172,15 @@ select_remote_version() {
 
   echo "$versions" | ./src/semver-select -c "$constraint" -n 1 -i -
 }
+
+select_go_version_from_file() {
+  local go_file_path="$1"
+
+  file_name="$(basename "$go_file_path")"
+  if [ "$file_name" != "go.mod" ] && [ "$file_name" != "go.work" ]; then
+    echo "::error ::File is not go.mod nor go.work"
+    return
+  fi
+
+  perl -nle 'print $1 if /^go (\d\.\d+)/' < "$go_file_path"
+}

--- a/src/run
+++ b/src/run
@@ -38,7 +38,7 @@ if [ "$constraint" = "tip" ] || [ "$constraint" = "gotip" ]; then
 fi
 
 if [ -z "$constraint" ]; then
-  constraint="$(select_go_version_from_file "$GITHUB_WORKSPACE/$GO_VERSION_FILE")"
+  constraint=">=$(select_go_version_from_file "$GITHUB_WORKSPACE/$GO_VERSION_FILE")"
 fi
 
 install_parent="$RUNNER_WORKSPACE/setup-go-faster/go"

--- a/src/run
+++ b/src/run
@@ -2,9 +2,10 @@
 
 # required global vars:
 # RUNNER_TOOL_CACHE         # provided by action
-# GO_VERSION= version constraint
 #
 # optional vars:
+# GO_VERSION= version constraint
+# GO_VERSION_FILE= path to go.mod or go.work
 # INSTALL_GO_FORCE                                     # set to non-empty to force the install
 
 set -e
@@ -19,10 +20,26 @@ debug_out starting run
 export INSTALL_GO_TIP
 
 # shellcheck disable=2153 # false positive about GO_VERSION being a misspelling of go_version
+if [ -z "$GO_VERSION" ] && [ -z "$GO_VERSION_FILE" ]; then
+  echo "::error ::Either go-version or go-version-file must be specified"
+  exit 1
+fi
+
+# shellcheck disable=2153 # false positive about GO_VERSION being a misspelling of go_version
+if [ -n "$GO_VERSION" ] && [ -n "$GO_VERSION_FILE" ]; then
+  echo "::warning ::Both go-version or go-version-file are set, but only go-version will be used"
+  exit 1
+fi
+
+# shellcheck disable=2153 # false positive about GO_VERSION being a misspelling of go_version
 constraint="$GO_VERSION"
 if [ "$constraint" = "tip" ] || [ "$constraint" = "gotip" ]; then
   constraint='*'
   INSTALL_GO_TIP=1
+fi
+
+if [ -z "$constraint" ]; then
+  constraint="$(select_go_version_from_file "$GITHUB_WORKSPACE/$GO_VERSION_FILE")"
 fi
 
 install_parent="$RUNNER_WORKSPACE/setup-go-faster/go"

--- a/src/run
+++ b/src/run
@@ -28,7 +28,6 @@ fi
 # shellcheck disable=2153 # false positive about GO_VERSION being a misspelling of go_version
 if [ -n "$GO_VERSION" ] && [ -n "$GO_VERSION_FILE" ]; then
   echo "::warning ::Both go-version or go-version-file are set, but only go-version will be used"
-  exit 1
 fi
 
 # shellcheck disable=2153 # false positive about GO_VERSION being a misspelling of go_version


### PR DESCRIPTION
Something I've been missing from actions/setup-go.

It makes sure at least one of the inputs `go-version` or `go-version-file` is set, with the former taking precedence.
