### PR TITLE
Support more runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ Look at those outputs. If you want to use GOPATH or GOMODCACHE as input in some
 other step, you can just grab it from setup-go-faster\'s output instead of
 having to add another step just to set an environment variable.
 
+### Supported Systems
+
+Setup-go-faster supports these runner systems:
+
+| RUNNER_OS | RUNNER_ARCH | go system     |
+|-----------|-------------|---------------|
+| Linux     | X86         | linux/386     |
+| Linux     | X64         | linux/amd64   |
+| Linux     | ARM64       | linux/arm64   |
+| MacOS     | X64         | darwin/amd64  |
+| MacOS     | ARM64       | darwin/arm64  |
+| Windows   | X86         | windows/386   |
+| Windows   | X64         | windows/amd64 |
+| Windows   | ARM64       | windows/arm64 |
+
 ### What\'s missing?
 
 Just the `stable` input. I don\'t understand what `stable` adds for

--- a/src/lib
+++ b/src/lib
@@ -4,6 +4,19 @@ set -e
 
 CDPATH="" cd -- "$(dirname -- "$0")/.."
 
+supported_system() {
+  grep -q "'$1'" <<< "
+'linux/386'
+'linux/amd64'
+'linux/arm64'
+'darwin/amd64'
+'darwin/arm64'
+'windows/386'
+'windows/amd64'
+'windows/arm64'
+"
+}
+
 goos() {
   case "$RUNNER_OS" in
     macOS)
@@ -19,6 +32,55 @@ goos() {
       uname -s | tr '[:upper:]' '[:lower:]'
       ;;
   esac
+}
+
+# get the arch from uname in case RUNNER_ARCH is not set
+# copied from https://github.com/client9/shlib
+uname_arch() {
+  arch=$(uname -m)
+  case $arch in
+    x86_64) arch="amd64" ;;
+    x86) arch="386" ;;
+    i686) arch="386" ;;
+    i386) arch="386" ;;
+    aarch64) arch="arm64" ;;
+    armv5*) arch="armv5" ;;
+    armv6*) arch="armv6" ;;
+    armv7*) arch="armv7" ;;
+  esac
+  echo ${arch}
+}
+
+# Get the arch to download. Use RUNNER_ARCH first, then uname if not set.
+goarch() {
+  case "$RUNNER_ARCH" in
+    X86)
+      echo "386"
+      ;;
+    X64)
+      echo "amd64"
+      ;;
+    ARM64)
+      echo "arm64"
+      ;;
+    *)
+      uname_arch
+      ;;
+  esac
+}
+
+go_system() {
+  echo "$(goos)/$(goarch)"
+}
+
+# returns the os part of os/arch
+system_os() {
+  echo "${1%%/*}"
+}
+
+# returns the arch part of os/arch
+system_arch() {
+  echo "${1##*/}"
 }
 
 debug_out() {
@@ -39,17 +101,14 @@ sdk_dir() {
   echo "$(homedir)/sdk"
 }
 
-extension() {
-  if [ "$(goos)" = "windows" ]; then
-    echo ".zip"
-  else
-    echo ".tar.gz"
-  fi
-}
-
 version_archive_name() {
   local version="$1"
-  echo "$version.$(goos)-amd64$(extension)"
+  local system="$2"
+  local extension=".tar.gz"
+  if [ "$(system_os "$system")" = "windows" ]; then
+    extension=".zip"
+  fi
+  echo "$version.$(system_os "$system")-$(system_arch "$system")$extension"
 }
 
 init_tmpdir() {
@@ -65,7 +124,8 @@ init_tmpdir() {
 
 download_go_url() {
   local go_version="$1"
-  archive_name="$(version_archive_name go"$go_version")"
+  local system="$2"
+  archive_name="$(version_archive_name go"$go_version" "$system")"
   echo "https://storage.googleapis.com/golang/$archive_name"
 }
 
@@ -73,18 +133,23 @@ install_go() {
   local go_version="${1#go}"
   local target_dir="$2"
   debug_out "installing go $go_version to $target_dir"
+  local system
+  system="$(go_system)"
+  if ! supported_system "$system"; then
+    echo "::error ::Unsupported system: $system"
+    return 1
+  fi
   rm -rf "$target_dir"
   mkdir -p "$(dirname "$target_dir")"
   tmpdir="$(init_tmpdir)"
   cd "$tmpdir"
 
-  archive_name="$(version_archive_name go"$go_version")"
+  archive_name="$(version_archive_name go"$go_version" "$system")"
 
   # 4 retries is 15 seconds of waiting
-  curl -s --retry 4 --fail -O "$(download_go_url "$go_version")"
+  curl -s --retry 4 --fail -O "$(download_go_url "$go_version" "$system")"
 
-  pwd
-  if [ "$(extension)" = ".zip" ]; then
+  if [ "${archive_name: -4}" == ".zip" ]; then
     7z x "$archive_name"
   else
     tar -xzf "$archive_name"

--- a/src/lib_test.sh
+++ b/src/lib_test.sh
@@ -18,17 +18,22 @@ test_homedir() {
 }
 
 test_download_go_url() {
-  assertEquals \
-    "https://storage.googleapis.com/golang/go1.15.5.linux-amd64.tar.gz" \
-    "$(RUNNER_OS=Linux download_go_url "1.15.5")"
+  run_test() {
+    local system="$1"
+    local go_version="$2"
+    local want_url="$3"
+    got_url="$(download_go_url "$go_version" "$system")"
+    assertEquals "$want_url" "$got_url"
+  }
 
-  assertEquals \
-    "https://storage.googleapis.com/golang/go1.15.5.darwin-amd64.tar.gz" \
-    "$(RUNNER_OS=macOS download_go_url "1.15.5")"
-
-  assertEquals \
-    "https://storage.googleapis.com/golang/go1.15.5.windows-amd64.zip" \
-    "$(RUNNER_OS=Windows download_go_url "1.15.5")"
+  run_test linux/amd64 1.15.5 "https://storage.googleapis.com/golang/go1.15.5.linux-amd64.tar.gz"
+  run_test linux/386 1.15.5 "https://storage.googleapis.com/golang/go1.15.5.linux-386.tar.gz"
+  run_test linux/arm64 1.15.5 "https://storage.googleapis.com/golang/go1.15.5.linux-arm64.tar.gz"
+  run_test darwin/amd64 1.15.5 "https://storage.googleapis.com/golang/go1.15.5.darwin-amd64.tar.gz"
+  run_test darwin/arm64 1.15.5 "https://storage.googleapis.com/golang/go1.15.5.darwin-arm64.tar.gz"
+  run_test windows/amd64 1.15.5 "https://storage.googleapis.com/golang/go1.15.5.windows-amd64.zip"
+  run_test windows/386 1.15.5 "https://storage.googleapis.com/golang/go1.15.5.windows-386.zip"
+  run_test windows/arm64 1.15.5 "https://storage.googleapis.com/golang/go1.15.5.windows-arm64.zip"
 }
 
 test_is_precise_version() {
@@ -141,6 +146,24 @@ x;go1.15.7'
     got="$(select_remote_version "$input" "$versions")"
     assertEquals "failed on input '$input'" "$want" "$got"
   done
+}
+
+test_supported_system() {
+  assertTrue "linux/amd64" 'supported_system "linux/amd64"'
+  assertTrue "linux/386" 'supported_system "linux/386"'
+  assertTrue "linux/arm64" 'supported_system "linux/arm64"'
+  assertTrue "darwin/amd64" 'supported_system "darwin/amd64"'
+  assertTrue "darwin/arm64" 'supported_system "darwin/arm64"'
+  assertTrue "windows/amd64" 'supported_system "windows/amd64"'
+  assertTrue "windows/386" 'supported_system "windows/386"'
+  assertTrue "windows/arm64" 'supported_system "windows/arm64"'
+
+  assertFalse "linux/arm" 'supported_system "linux/arm"'
+  assertFalse "darwin/386" 'supported_system "darwin/386"'
+  assertFalse "asdf" 'supported_system "asdf"'
+  assertFalse "" 'supported_system ""'
+  assertFalse " " 'supported_system " "'
+
 }
 
 . ./external/shunit2

--- a/src/lib_test_long.sh
+++ b/src/lib_test_long.sh
@@ -17,7 +17,7 @@ test_install_go() {
     version="1.15.4"
     install_go "$version" "$target"
     got_version="$("$target/bin/go" version)"
-    assertEquals "go version go1.15.4 $(goos)/amd64" "$got_version"
+    assertEquals "go version go1.15.4 $(go_system)" "$got_version"
   )
 }
 

--- a/src/semver-select
+++ b/src/semver-select
@@ -22,7 +22,7 @@ download() {
   skip_download && return
   mkdir -p "$(dirname "$bin_path")"
   url="https://github.com/WillAbides/semver-select/releases/download/v"
-  url+="$target_version/semver-select_${target_version}_$(goos)_amd64"
+  url+="$target_version/semver-select_${target_version}_$(goos)_$(goarch)"
   [ "$(goos)" = "windows" ] && url+=".exe"
   curl -s --fail -o "$bin_path" --retry 4 -L "$url"
   chmod +x "$bin_path"


### PR DESCRIPTION
As mentioned in #29, setup-go-faster only supports amd64 architectures. This PR updates it to support more architectures. It also updates README.md to explicitly list which systems are supported.