### PR TITLE
ci: add release workflow driven by willabides/release-train

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -6,10 +6,6 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   check-pr:
     name: check-pr

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -18,7 +18,24 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+      - name: Download release-train binary
+        id: rt
+        env:
+          RT_VERSION: '3.8.5'
+          RT_SHA256: '78d942e422f64089c92b54165023d64416b677b600244486579110f76a64c516'
+        run: |
+          set -euo pipefail
+          url="https://github.com/WillAbides/release-train/releases/download/v${RT_VERSION}/release-train_${RT_VERSION}_linux_amd64.tar.gz"
+          dest="$RUNNER_TEMP/release-train"
+          mkdir -p "$dest"
+          cd "$dest"
+          curl --fail --silent --show-error --location --output rt.tar.gz "$url"
+          echo "${RT_SHA256}  rt.tar.gz" | sha256sum -c -
+          tar -xzf rt.tar.gz
+          chmod +x release-train
+          echo "bin=$dest/release-train" >>"$GITHUB_OUTPUT"
       - name: release-train (check-pr)
         uses: WillAbides/release-train@cd01ea9e19bb396bf659f61e1c840c5174b92de8 # v3.8.5
         with:
+          release-train-bin: ${{ steps.rt.outputs.bin }}
           release-refs: main

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,28 @@
+name: release-check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-pr:
+    name: check-pr
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: release-train (check-pr)
+        uses: WillAbides/release-train@cd01ea9e19bb396bf659f61e1c840c5174b92de8 # v3.8.5
+        with:
+          release-refs: main

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -7,7 +7,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -22,10 +22,27 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+      - name: Download release-train binary
+        id: rt
+        env:
+          RT_VERSION: '3.8.5'
+          RT_SHA256: '78d942e422f64089c92b54165023d64416b677b600244486579110f76a64c516'
+        run: |
+          set -euo pipefail
+          url="https://github.com/WillAbides/release-train/releases/download/v${RT_VERSION}/release-train_${RT_VERSION}_linux_amd64.tar.gz"
+          dest="$RUNNER_TEMP/release-train"
+          mkdir -p "$dest"
+          cd "$dest"
+          curl --fail --silent --show-error --location --output rt.tar.gz "$url"
+          echo "${RT_SHA256}  rt.tar.gz" | sha256sum -c -
+          tar -xzf rt.tar.gz
+          chmod +x release-train
+          echo "bin=$dest/release-train" >>"$GITHUB_OUTPUT"
       - name: release-train
         id: release
         uses: WillAbides/release-train@cd01ea9e19bb396bf659f61e1c840c5174b92de8 # v3.8.5
         with:
+          release-train-bin: ${{ steps.rt.outputs.bin }}
           create-tag: true
           create-release: true
           release-refs: main

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,38 +1,18 @@
-name: release
+name: release-publish
 
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
 
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  check-pr:
-    name: check-pr
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      pull-requests: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-      - name: release-train (check-pr)
-        uses: WillAbides/release-train@cd01ea9e19bb396bf659f61e1c840c5174b92de8 # v3.8.5
-        with:
-          release-refs: main
-
   publish:
     name: publish
-    if: github.event_name == 'push'
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: release
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check-pr:
+    name: check-pr
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: release-train (check-pr)
+        uses: WillAbides/release-train@cd01ea9e19bb396bf659f61e1c840c5174b92de8 # v3.8.5
+        with:
+          release-refs: main
+
+  publish:
+    name: publish
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: release-train
+        id: release
+        uses: WillAbides/release-train@cd01ea9e19bb396bf659f61e1c840c5174b92de8 # v3.8.5
+        with:
+          create-tag: true
+          create-release: true
+          release-refs: main
+      - name: Advance major version branch
+        if: steps.release.outputs.created-tag == 'true'
+        env:
+          TAG: ${{ steps.release.outputs.release-tag }}
+        run: |
+          set -euo pipefail
+
+          case "$TAG" in
+            *-*)
+              echo "Prerelease $TAG; not advancing major branch." >&2
+              exit 0
+              ;;
+          esac
+
+          case "$TAG" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "Unexpected release tag shape: $TAG" >&2
+              exit 1
+              ;;
+          esac
+
+          major="${TAG%%.*}"
+          commit="$(git rev-list -n1 "$TAG")"
+
+          git fetch origin "$major" 2>/dev/null || true
+
+          if git show-ref --verify --quiet "refs/remotes/origin/$major"; then
+            if ! git merge-base --is-ancestor "origin/$major" "$commit"; then
+              echo "Refusing to move $major non-fast-forward to $TAG" >&2
+              echo "  current origin/$major: $(git rev-parse origin/$major)" >&2
+              echo "  new commit:            $commit" >&2
+              exit 1
+            fi
+          fi
+
+          git push origin "$commit:refs/heads/$major"


### PR DESCRIPTION
Adds two release workflows that replace the laptop-PAT `script/release` flow with a workflow-driven release that fires on PR merge to `main`.

## What this PR does

Two workflow files, one per trigger:

- **`.github/workflows/release-check.yml`** — runs on `pull_request` (`opened`/`reopened`/`synchronize`/`labeled`/`unlabeled`) with a read-only token. Invokes release-train in check-pr mode to validate the PR is labeled with one of `semver:none / patch / minor / breaking`.
- **`.github/workflows/release-publish.yml`** — runs on `push` to `main` with `contents: write`. Invokes release-train to cut the tag + release, then advances the major-version branch (`v1`) to point at the new tag.

The major-branch advance is paranoid:

- peels the new tag to a commit (handles annotated tags),
- refuses to advance the branch non-fast-forward,
- skips prereleases (tags containing `-`),
- and creates a fresh major branch the first time a new major ships (e.g. v2 branch appears automatically when `v2.0.0` is released).

`actions/checkout` and `WillAbides/release-train` are SHA-pinned. The release-train binary is downloaded with a checked-in SHA-256 and passed via the action's `release-train-bin` input — works around [release-train#193](https://github.com/WillAbides/release-train/issues/193) and is a strict security improvement (action source and binary are independently pinned and verified).

Concurrency: `release-check` has none (read-only, idempotent, Checks API collapses duplicate results). `release-publish` is keyed by workflow name with `cancel-in-progress: false` so a publish run is never killed mid-flight and only one publish runs at a time.

## Pre-merge checklist (out-of-band)

1. **Create `semver:*` labels** on the repo:

   ```sh
   gh label create semver:none     --description "No release"           --color ededed
   gh label create semver:patch    --description "Patch release"         --color 0e8a16
   gh label create semver:minor    --description "Minor release"         --color 1d76db
   gh label create semver:breaking --description "Major / breaking"      --color b60205
   ```

2. **Configure branch protection on `main`**. Solo-maintainer config:
   - Require a pull request before merging, **0 required reviewers** (you can't approve your own PRs).
   - Require status checks: `cibuild` (current CI lint+codegen job). Optionally add `release-check / check-pr` once it has run at least once on this PR.
   - Block force pushes and deletions.
   - Leave admin bypass enabled as an escape hatch.

3. **Label this PR** `semver:patch` so the resulting release will be `v1.15.1`.

## Post-merge validation

- A `release-publish / publish` workflow run completes on the merge commit.
- A new tag `v1.15.1` exists with a GitHub release.
- `origin/v1` advances to the v1.15.1 commit. Consumers using `setup-go-faster@v1` get the new version.

## Follow-ups (separate PRs)

- Decommission `script/release` and revoke the release PAT after the first successful workflow-driven release.

## Notes for reviewers

- The advance step runs `git push origin "$commit:refs/heads/$major"` using the GITHUB_TOKEN credential installed by `actions/checkout`. This requires `v1` to **not** be branch-protected (it's a floating pointer, not a real development branch).
- If `release-train` itself isn't released through a hardened pipeline, that's a transitive dependency worth examining once this lands (its binary is checked into the release-train repo at the pinned SHA, so we're at least pinned).