### PR TITLE
Stream go.dev's JSON release feed in-process, remove goreleases mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
       - uses: WillAbides/setup-go-faster@b78d00946efb1fce63dc2e3d89f715a66ca26a0b # v1.17.2
         with:
           go-version: '1.26.3'
+      - name: go unit tests
+        run: script/test-go
       - name: cross-compile
         run: |
           mkdir -p ./out

--- a/.github/workflows/script/cross-compile-goversion-select
+++ b/.github/workflows/script/cross-compile-goversion-select
@@ -32,7 +32,7 @@ for platform in "${platforms[@]}"; do
     asset="${asset}.exe"
   fi
   echo "building $asset"
-  GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 \
+  GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 GOEXPERIMENT=jsonv2 \
     go -C tools/goversion-select build \
       -trimpath \
       -ldflags='-s -w' \

--- a/script/lint
+++ b/script/lint
@@ -10,12 +10,14 @@ script/bindown -q install shellcheck
 script/bindown -q install zizmor
 
 # Skip non-script artifacts in src/ (e.g. goversion-select.version,
-# a bare release tag written by the release-train pre-tag hook).
+# a bare release tag written by the release-train pre-tag hook,
+# or directories like testdata/).
 src_files=""
 for f in ./src/*; do
   case "$f" in
     *.version) continue ;;
   esac
+  [ -d "$f" ] && continue
   src_files="$src_files $f"
 done
 

--- a/script/test-go
+++ b/script/test-go
@@ -1,0 +1,23 @@
+#!/bin/sh
+#/ script/test-go runs the Go unit tests for tools/goversion-select.
+#/
+#/ Kept separate from script/test (which runs the bash unit tests on
+#/ every CI matrix runner) because not every runner ships a Go version
+#/ recent enough to build tools/goversion-select (the go directive
+#/ requires 1.26.3, and the --json-input mode also requires
+#/ GOEXPERIMENT=jsonv2 which is only available on that release line).
+#/
+#/ The build_goversion_select CI job already installs Go 1.26.3 for the
+#/ cross-compile, so wiring this script in there is the cheapest way to
+#/ exercise the Go tests on every PR.
+
+set -e
+
+CDPATH="" cd -- "$(dirname -- "$0")/.."
+
+if ! command -v go > /dev/null 2>&1; then
+  echo "script/test-go: skipping — go not on PATH" >&2
+  exit 0
+fi
+
+GOEXPERIMENT=jsonv2 go -C tools/goversion-select test ./...

--- a/src/goversion-select
+++ b/src/goversion-select
@@ -63,7 +63,7 @@ build_from_source() {
   mkdir -p "$(dirname "$bin_path")"
   local abs_bin
   abs_bin="$(cd "$(dirname "$bin_path")" && pwd)/$(basename "$bin_path")"
-  (cd "$src_dir" && go build -trimpath -ldflags='-s -w' -o "$abs_bin" .)
+  (cd "$src_dir" && GOEXPERIMENT=jsonv2 go build -trimpath -ldflags='-s -w' -o "$abs_bin" .)
 }
 
 if [ -n "$VERSION" ]; then

--- a/src/lib
+++ b/src/lib
@@ -254,8 +254,20 @@ select_remote_version_streaming() {
   if is_precise_version "$constraint"; then
     return
   fi
-  curl -sfL --compressed --retry 4 "$GODEV_JSON_URL" \
-    | ./src/"goversion-select" --orig --json-input -c "$constraint"
+  # file:// URLs are used by the test suite to feed in a checked-in
+  # fixture. Curl's MSYS-on-Windows file:// path handling is unreliable
+  # (it doesn't understand /c/...-style paths), so dispatch local files
+  # through cat for portability.
+  case "$GODEV_JSON_URL" in
+    file://*)
+      cat -- "${GODEV_JSON_URL#file://}" \
+        | ./src/"goversion-select" --orig --json-input -c "$constraint"
+      ;;
+    *)
+      curl -sfL --compressed --retry 4 "$GODEV_JSON_URL" \
+        | ./src/"goversion-select" --orig --json-input -c "$constraint"
+      ;;
+  esac
 }
 
 # uses goversion-select to convert a go version to canonical form

--- a/src/lib
+++ b/src/lib
@@ -257,7 +257,9 @@ _fetch_json_url() {
 # goversion-select exits on it, curl receives SIGPIPE, and the TCP
 # transfer short-circuits.
 #
-# GODEV_JSON_URL is overridable so tests can point at a file:// fixture.
+# GODEV_JSON_URL is overridable so tests can point at a file:// fixture,
+# and so anyone running into a go.dev outage can swap in a mirror without
+# patching the action.
 #
 # Note: curl runs without -S to suppress the "Failure writing output to
 # destination" stderr line that fires every time the downstream exits

--- a/src/lib
+++ b/src/lib
@@ -237,6 +237,19 @@ select_remote_version() {
   echo "$versions" | ./src/"goversion-select" --orig -c "$constraint" -
 }
 
+# _fetch_json_url emits the bytes of a JSON endpoint URL on stdout.
+# file:// URLs go through cat for Windows-MSYS portability (curl on
+# Git-bash mis-handles /c/-style paths); anything else goes through
+# curl with the same retry / --compressed setup the streaming consumer
+# expects. Underscore-prefixed because it's a helper, not the public
+# library surface.
+_fetch_json_url() {
+  case "$1" in
+    file://*) cat -- "${1#file://}" ;;
+    *) curl -sfL --compressed --retry 4 "$1" ;;
+  esac
+}
+
 # select_remote_version_streaming picks the highest matching Go release
 # by streaming go.dev's /dl/?mode=json&include=all payload through
 # goversion-select --json-input. go.dev returns the array in
@@ -254,20 +267,8 @@ select_remote_version_streaming() {
   if is_precise_version "$constraint"; then
     return
   fi
-  # file:// URLs are used by the test suite to feed in a checked-in
-  # fixture. Curl's MSYS-on-Windows file:// path handling is unreliable
-  # (it doesn't understand /c/...-style paths), so dispatch local files
-  # through cat for portability.
-  case "$GODEV_JSON_URL" in
-    file://*)
-      cat -- "${GODEV_JSON_URL#file://}" \
-        | ./src/"goversion-select" --orig --json-input -c "$constraint"
-      ;;
-    *)
-      curl -sfL --compressed --retry 4 "$GODEV_JSON_URL" \
-        | ./src/"goversion-select" --orig --json-input -c "$constraint"
-      ;;
-  esac
+  _fetch_json_url "$GODEV_JSON_URL" \
+    | ./src/"goversion-select" --orig --json-input -c "$constraint"
 }
 
 # uses goversion-select to convert a go version to canonical form
@@ -306,23 +307,32 @@ get_known_versions() {
   cat "$file"
 }
 
+# get_stable_minor_version returns the minor version number of the
+# current stable Go release (the X in 1.X.Y), e.g. "20" for go1.20.7.
+#
+# Source is the go.dev /dl/?mode=json endpoint (no include=all), which
+# returns just [latest_stable, latest_oldstable] (~23 KB). We pipe the
+# payload through goversion-select --json-input -c '*' which picks the
+# first match in the array — the latest stable release — then peel "go"
+# and split out the minor in pure bash.
 get_stable_minor_version() {
-  local versions_url="$1"
-  local tmp_dir="$2"
-  local versions
-  get_known_versions "$versions_url" "$tmp_dir" | grep -E '^go1\.[0-9]+(\.[0-9]+)?$' | head -1 | awk -F. '{print $2}'
+  local v
+  v="$(_fetch_json_url "$1" | ./src/"goversion-select" --orig --json-input -c '*')"
+  v="${v#go}"
+  v="${v#*.}"
+  echo "${v%%.*}"
 }
 
 resolve_constraint_alias() {
   local constraint="$1"
-  local versions_url="$2"
-  local tmp_dir="$3"
+  local godev_stable_url="$2"
+  local minor_version
   case "$constraint" in
     stable)
-      echo "1.$(get_stable_minor_version "$versions_url" "$tmp_dir").x"
+      echo "1.$(get_stable_minor_version "$godev_stable_url").x"
       ;;
     oldstable)
-      minor_version="$(get_stable_minor_version "$versions_url" "$tmp_dir")"
+      minor_version="$(get_stable_minor_version "$godev_stable_url")"
       echo "1.$((minor_version - 1)).x"
       ;;
     *)

--- a/src/lib
+++ b/src/lib
@@ -177,8 +177,10 @@ exe_name() {
 
 is_precise_version() {
   [[ $1 =~ ^[0-9]+(.([0-9]+)(.[0-9]+)?)?([A-Za-z0-9]+)?$ ]] || return 1
-  # false when minor is >= 21 and patch is empty
-  [ -z "${BASH_REMATCH[2]}" ] || [ "${BASH_REMATCH[2]}" -lt 21 ] || [ -n "${BASH_REMATCH[3]}" ]
+  # false when minor is >= 21 and patch is empty and there is no
+  # pre-release suffix; a non-empty suffix like "rc4" or "beta1"
+  # identifies a single release with no ambiguity.
+  [ -z "${BASH_REMATCH[2]}" ] || [ "${BASH_REMATCH[2]}" -lt 21 ] || [ -n "${BASH_REMATCH[3]}" ] || [ -n "${BASH_REMATCH[4]}" ]
 }
 
 select_go_version() {
@@ -233,6 +235,27 @@ select_remote_version() {
   fi
 
   echo "$versions" | ./src/"goversion-select" --orig -c "$constraint" -
+}
+
+# select_remote_version_streaming picks the highest matching Go release
+# by streaming go.dev's /dl/?mode=json&include=all payload through
+# goversion-select --json-input. go.dev returns the array in
+# semver-descending order, so the first match is the highest match;
+# goversion-select exits on it, curl receives SIGPIPE, and the TCP
+# transfer short-circuits.
+#
+# GODEV_JSON_URL is overridable so tests can point at a file:// fixture.
+#
+# Note: curl runs without -S to suppress the "Failure writing output to
+# destination" stderr line that fires every time the downstream exits
+# early on a match. --fail still surfaces real HTTP errors.
+select_remote_version_streaming() {
+  local constraint="$1"
+  if is_precise_version "$constraint"; then
+    return
+  fi
+  curl -sfL --compressed --retry 4 "$GODEV_JSON_URL" \
+    | ./src/"goversion-select" --orig --json-input -c "$constraint"
 }
 
 # uses goversion-select to convert a go version to canonical form

--- a/src/lib_test.sh
+++ b/src/lib_test.sh
@@ -51,6 +51,8 @@ test_is_precise_version() {
 1.16rc1
 1.21.0
 1.21.1
+1.21rc4
+1.26beta2
   '
 
   for v in $versions; do
@@ -148,6 +150,39 @@ x;go1.15.7'
     input="$(echo "$td" | cut -d ';' -f1)"
     want="$(echo "$td" | cut -d ';' -f2)"
     got="$(select_remote_version "$input" "$versions")"
+    assertEquals "failed on input '$input'" "$want" "$got"
+  done
+}
+
+test_select_remote_version_streaming() {
+  # Use the checked-in fixture so the test stays offline-reproducible
+  # and doesn't depend on go.dev's current state.
+  GODEV_JSON_URL="file://$PWD/src/testdata/go-dl-all-sample.json"
+  export GODEV_JSON_URL
+
+  # Each row: <constraint>;<want>
+  #
+  # The fixture mirrors the goreleases snapshot pinned at the same SHA
+  # as STABLE_VERSIONS_URL above, so the expected outputs match what
+  # the legacy newline-stdin flow would have produced against that
+  # snapshot. is_precise_version cases short-circuit before the curl
+  # ever runs.
+  tests='*;go1.20.7
+1.17.x;go1.17.13
+1.16.x;go1.16.15
+1.15.x;go1.15.15
+1.20.x;go1.20.7
+1.19.x;go1.19.12
+^1;go1.20.7
+^1.20.999;
+1.13.x;go1.13.15
+1.99.x;
+>=1.20.7;go1.20.7'
+
+  for td in $tests; do
+    input="$(echo "$td" | cut -d ';' -f1)"
+    want="$(echo "$td" | cut -d ';' -f2)"
+    got="$(select_remote_version_streaming "$input")"
     assertEquals "failed on input '$input'" "$want" "$got"
   done
 }

--- a/src/lib_test.sh
+++ b/src/lib_test.sh
@@ -8,9 +8,12 @@ setUp() {
   . src/lib
 }
 
-# Nothing special about this one. It just happens to be HEAD of main when writing this.
-# Most recent version is go1.21rc4
-STABLE_VERSIONS_URL="https://raw.githubusercontent.com/WillAbides/goreleases/077db58ac86a8a2fb63c90817090e132eded0f3d/versions.txt"
+# Both fixture files mirror the same goreleases snapshot
+# (077db58a...) that the prior round of long tests pinned, so the
+# expected stable / oldstable resolution stays consistent across
+# the legacy versions.txt path and the new ?mode=json path.
+GODEV_STABLE_FIXTURE="file://$PWD/src/testdata/go-dl-stable-sample.json"
+GODEV_ALL_FIXTURE="file://$PWD/src/testdata/go-dl-all-sample.json"
 
 test_homedir() {
   (
@@ -157,14 +160,14 @@ x;go1.15.7'
 test_select_remote_version_streaming() {
   # Use the checked-in fixture so the test stays offline-reproducible
   # and doesn't depend on go.dev's current state.
-  GODEV_JSON_URL="file://$PWD/src/testdata/go-dl-all-sample.json"
+  GODEV_JSON_URL="$GODEV_ALL_FIXTURE"
   export GODEV_JSON_URL
 
   # Each row: <constraint>;<want>
   #
   # The fixture mirrors the goreleases snapshot pinned at the same SHA
-  # as STABLE_VERSIONS_URL above, so the expected outputs match what
-  # the legacy newline-stdin flow would have produced against that
+  # used by the long tests, so the expected outputs match what the
+  # legacy newline-stdin flow would have produced against that
   # snapshot. is_precise_version cases short-circuit before the curl
   # ever runs.
   tests='*;go1.20.7
@@ -206,9 +209,9 @@ test_supported_system() {
 }
 
 test_resolve_constraint_alias() {
-  assertEquals "1.20.x" "$(resolve_constraint_alias "stable" "$STABLE_VERSIONS_URL" "$SHUNIT_TMPDIR")"
-  assertEquals "1.19.x" "$(resolve_constraint_alias "oldstable" "$STABLE_VERSIONS_URL" "$SHUNIT_TMPDIR")"
-  assertEquals "xxx" "$(resolve_constraint_alias "xxx" "$STABLE_VERSIONS_URL" "$SHUNIT_TMPDIR")"
+  assertEquals "1.20.x" "$(resolve_constraint_alias "stable" "$GODEV_STABLE_FIXTURE")"
+  assertEquals "1.19.x" "$(resolve_constraint_alias "oldstable" "$GODEV_STABLE_FIXTURE")"
+  assertEquals "xxx" "$(resolve_constraint_alias "xxx" "$GODEV_STABLE_FIXTURE")"
 }
 
 . ./external/shunit2

--- a/src/run
+++ b/src/run
@@ -13,7 +13,8 @@
 # IGNORE_LOCAL_GO    # set to non-empty to ignore local go installations
 #
 # for testing:
-# VERSIONS_URL       # override the url used to get the list of known versions
+# GODEV_JSON_URL     # override the url used for the full list of releases
+# GODEV_STABLE_URL   # override the url used for stable / oldstable alias resolution
 # SKIP_MATCHER       # don't issue the add-matcher command because it breaks when running tests on windows
 
 set -e
@@ -23,8 +24,8 @@ CDPATH="" cd -- "$(dirname -- "$0")/.."
 
 . src/lib
 
-VERSIONS_URL="${VERSIONS_URL:-https://raw.githubusercontent.com/WillAbides/goreleases/main/versions.txt}"
 GODEV_JSON_URL="${GODEV_JSON_URL:-https://go.dev/dl/?mode=json&include=all}"
+GODEV_STABLE_URL="${GODEV_STABLE_URL:-https://go.dev/dl/?mode=json}"
 
 debug_out starting run
 
@@ -52,7 +53,7 @@ if [ "$constraint" = "tip" ] || [ "$constraint" = "gotip" ]; then
   INSTALL_GO_TIP=1
 fi
 
-constraint="$(resolve_constraint_alias "$constraint" "$VERSIONS_URL" "$tmp_dir")"
+constraint="$(resolve_constraint_alias "$constraint" "$GODEV_STABLE_URL")"
 
 if [ -z "$constraint" ]; then
   constraint=">=$(select_go_version_from_file "$GITHUB_WORKSPACE/$GO_VERSION_FILE")"

--- a/src/run
+++ b/src/run
@@ -12,9 +12,11 @@
 # INSTALL_GO_FORCE   # set to non-empty to force the install
 # IGNORE_LOCAL_GO    # set to non-empty to ignore local go installations
 #
-# for testing:
+# for testing or pointing at a mirror:
 # GODEV_JSON_URL     # override the url used for the full list of releases
 # GODEV_STABLE_URL   # override the url used for stable / oldstable alias resolution
+#
+# for testing:
 # SKIP_MATCHER       # don't issue the add-matcher command because it breaks when running tests on windows
 
 set -e

--- a/src/run
+++ b/src/run
@@ -24,6 +24,7 @@ CDPATH="" cd -- "$(dirname -- "$0")/.."
 . src/lib
 
 VERSIONS_URL="${VERSIONS_URL:-https://raw.githubusercontent.com/WillAbides/goreleases/main/versions.txt}"
+GODEV_JSON_URL="${GODEV_JSON_URL:-https://go.dev/dl/?mode=json&include=all}"
 
 debug_out starting run
 
@@ -81,8 +82,7 @@ if [ -z "$lv" ]; then
 fi
 
 if [ -z "$lv" ]; then
-  known_versions="$(get_known_versions "$VERSIONS_URL" "$tmp_dir")"
-  lv="$(select_remote_version "$constraint" "$known_versions")"
+  lv="$(select_remote_version_streaming "$constraint")"
   target_dir="$install_parent/${lv#go}/x64"
 fi
 

--- a/src/run_test_long.sh
+++ b/src/run_test_long.sh
@@ -22,6 +22,7 @@ do_test_run() {
   export GITHUB_OUTPUT="$tmp_dir/github_output"
   export GITHUB_ACTION_PATH="$PWD"
   export VERSIONS_URL="$STABLE_VERSIONS_URL"
+  export GODEV_JSON_URL="file://$PWD/src/testdata/go-dl-all-sample.json"
   export SKIP_MATCHER=1
   export IGNORE_LOCAL_GO=1
   export GOROOT=""

--- a/src/run_test_long.sh
+++ b/src/run_test_long.sh
@@ -8,10 +8,6 @@ setUp() {
   . src/lib
 }
 
-# Nothing special about this one. It just happens to be HEAD of main when writing this.
-# Most recent version is go1.21rc4
-STABLE_VERSIONS_URL="https://raw.githubusercontent.com/WillAbides/goreleases/077db58ac86a8a2fb63c90817090e132eded0f3d/versions.txt"
-
 do_test_run() {
   tmp_dir="$SHUNIT_TMPDIR"/test_run
   rm -rf -- "$tmp_dir"
@@ -21,8 +17,8 @@ do_test_run() {
   export RUNNER_WORKSPACE="$tmp_dir/runner_workspace"
   export GITHUB_OUTPUT="$tmp_dir/github_output"
   export GITHUB_ACTION_PATH="$PWD"
-  export VERSIONS_URL="$STABLE_VERSIONS_URL"
   export GODEV_JSON_URL="file://$PWD/src/testdata/go-dl-all-sample.json"
+  export GODEV_STABLE_URL="file://$PWD/src/testdata/go-dl-stable-sample.json"
   export SKIP_MATCHER=1
   export IGNORE_LOCAL_GO=1
   export GOROOT=""

--- a/src/testdata/go-dl-all-sample.json
+++ b/src/testdata/go-dl-all-sample.json
@@ -1,0 +1,794 @@
+[
+  {
+    "version": "go1.21rc4"
+  },
+  {
+    "version": "go1.21rc3"
+  },
+  {
+    "version": "go1.21rc2"
+  },
+  {
+    "version": "go1.21rc1"
+  },
+  {
+    "version": "go1.20.7"
+  },
+  {
+    "version": "go1.20.6"
+  },
+  {
+    "version": "go1.20.5"
+  },
+  {
+    "version": "go1.20.4"
+  },
+  {
+    "version": "go1.20.3"
+  },
+  {
+    "version": "go1.20.2"
+  },
+  {
+    "version": "go1.20.1"
+  },
+  {
+    "version": "go1.20"
+  },
+  {
+    "version": "go1.20rc3"
+  },
+  {
+    "version": "go1.20rc2"
+  },
+  {
+    "version": "go1.20rc1"
+  },
+  {
+    "version": "go1.19.12"
+  },
+  {
+    "version": "go1.19.11"
+  },
+  {
+    "version": "go1.19.10"
+  },
+  {
+    "version": "go1.19.9"
+  },
+  {
+    "version": "go1.19.8"
+  },
+  {
+    "version": "go1.19.7"
+  },
+  {
+    "version": "go1.19.6"
+  },
+  {
+    "version": "go1.19.5"
+  },
+  {
+    "version": "go1.19.4"
+  },
+  {
+    "version": "go1.19.3"
+  },
+  {
+    "version": "go1.19.2"
+  },
+  {
+    "version": "go1.19.1"
+  },
+  {
+    "version": "go1.19"
+  },
+  {
+    "version": "go1.19rc2"
+  },
+  {
+    "version": "go1.19rc1"
+  },
+  {
+    "version": "go1.19beta1"
+  },
+  {
+    "version": "go1.18.10"
+  },
+  {
+    "version": "go1.18.9"
+  },
+  {
+    "version": "go1.18.8"
+  },
+  {
+    "version": "go1.18.7"
+  },
+  {
+    "version": "go1.18.6"
+  },
+  {
+    "version": "go1.18.5"
+  },
+  {
+    "version": "go1.18.4"
+  },
+  {
+    "version": "go1.18.3"
+  },
+  {
+    "version": "go1.18.2"
+  },
+  {
+    "version": "go1.18.1"
+  },
+  {
+    "version": "go1.18"
+  },
+  {
+    "version": "go1.18rc1"
+  },
+  {
+    "version": "go1.18beta2"
+  },
+  {
+    "version": "go1.18beta1"
+  },
+  {
+    "version": "go1.17.13"
+  },
+  {
+    "version": "go1.17.12"
+  },
+  {
+    "version": "go1.17.11"
+  },
+  {
+    "version": "go1.17.10"
+  },
+  {
+    "version": "go1.17.9"
+  },
+  {
+    "version": "go1.17.8"
+  },
+  {
+    "version": "go1.17.7"
+  },
+  {
+    "version": "go1.17.6"
+  },
+  {
+    "version": "go1.17.5"
+  },
+  {
+    "version": "go1.17.4"
+  },
+  {
+    "version": "go1.17.3"
+  },
+  {
+    "version": "go1.17.2"
+  },
+  {
+    "version": "go1.17.1"
+  },
+  {
+    "version": "go1.17"
+  },
+  {
+    "version": "go1.17rc2"
+  },
+  {
+    "version": "go1.17rc1"
+  },
+  {
+    "version": "go1.17beta1"
+  },
+  {
+    "version": "go1.16.15"
+  },
+  {
+    "version": "go1.16.14"
+  },
+  {
+    "version": "go1.16.13"
+  },
+  {
+    "version": "go1.16.12"
+  },
+  {
+    "version": "go1.16.11"
+  },
+  {
+    "version": "go1.16.10"
+  },
+  {
+    "version": "go1.16.9"
+  },
+  {
+    "version": "go1.16.8"
+  },
+  {
+    "version": "go1.16.7"
+  },
+  {
+    "version": "go1.16.6"
+  },
+  {
+    "version": "go1.16.5"
+  },
+  {
+    "version": "go1.16.4"
+  },
+  {
+    "version": "go1.16.3"
+  },
+  {
+    "version": "go1.16.2"
+  },
+  {
+    "version": "go1.16.1"
+  },
+  {
+    "version": "go1.16"
+  },
+  {
+    "version": "go1.16rc1"
+  },
+  {
+    "version": "go1.16beta1"
+  },
+  {
+    "version": "go1.15.15"
+  },
+  {
+    "version": "go1.15.14"
+  },
+  {
+    "version": "go1.15.13"
+  },
+  {
+    "version": "go1.15.12"
+  },
+  {
+    "version": "go1.15.11"
+  },
+  {
+    "version": "go1.15.10"
+  },
+  {
+    "version": "go1.15.9"
+  },
+  {
+    "version": "go1.15.8"
+  },
+  {
+    "version": "go1.15.7"
+  },
+  {
+    "version": "go1.15.6"
+  },
+  {
+    "version": "go1.15.5"
+  },
+  {
+    "version": "go1.15.4"
+  },
+  {
+    "version": "go1.15.3"
+  },
+  {
+    "version": "go1.15.2"
+  },
+  {
+    "version": "go1.15.1"
+  },
+  {
+    "version": "go1.15"
+  },
+  {
+    "version": "go1.15rc2"
+  },
+  {
+    "version": "go1.15rc1"
+  },
+  {
+    "version": "go1.15beta1"
+  },
+  {
+    "version": "go1.14.15"
+  },
+  {
+    "version": "go1.14.14"
+  },
+  {
+    "version": "go1.14.13"
+  },
+  {
+    "version": "go1.14.12"
+  },
+  {
+    "version": "go1.14.11"
+  },
+  {
+    "version": "go1.14.10"
+  },
+  {
+    "version": "go1.14.9"
+  },
+  {
+    "version": "go1.14.8"
+  },
+  {
+    "version": "go1.14.7"
+  },
+  {
+    "version": "go1.14.6"
+  },
+  {
+    "version": "go1.14.5"
+  },
+  {
+    "version": "go1.14.4"
+  },
+  {
+    "version": "go1.14.3"
+  },
+  {
+    "version": "go1.14.2"
+  },
+  {
+    "version": "go1.14.1"
+  },
+  {
+    "version": "go1.14"
+  },
+  {
+    "version": "go1.14rc1"
+  },
+  {
+    "version": "go1.14beta1"
+  },
+  {
+    "version": "go1.13.15"
+  },
+  {
+    "version": "go1.13.14"
+  },
+  {
+    "version": "go1.13.13"
+  },
+  {
+    "version": "go1.13.12"
+  },
+  {
+    "version": "go1.13.11"
+  },
+  {
+    "version": "go1.13.10"
+  },
+  {
+    "version": "go1.13.9"
+  },
+  {
+    "version": "go1.13.8"
+  },
+  {
+    "version": "go1.13.7"
+  },
+  {
+    "version": "go1.13.6"
+  },
+  {
+    "version": "go1.13.5"
+  },
+  {
+    "version": "go1.13.4"
+  },
+  {
+    "version": "go1.13.3"
+  },
+  {
+    "version": "go1.13.2"
+  },
+  {
+    "version": "go1.13.1"
+  },
+  {
+    "version": "go1.13"
+  },
+  {
+    "version": "go1.13rc2"
+  },
+  {
+    "version": "go1.13rc1"
+  },
+  {
+    "version": "go1.13beta1"
+  },
+  {
+    "version": "go1.12.17"
+  },
+  {
+    "version": "go1.12.16"
+  },
+  {
+    "version": "go1.12.15"
+  },
+  {
+    "version": "go1.12.14"
+  },
+  {
+    "version": "go1.12.13"
+  },
+  {
+    "version": "go1.12.12"
+  },
+  {
+    "version": "go1.12.11"
+  },
+  {
+    "version": "go1.12.10"
+  },
+  {
+    "version": "go1.12.9"
+  },
+  {
+    "version": "go1.12.8"
+  },
+  {
+    "version": "go1.12.7"
+  },
+  {
+    "version": "go1.12.6"
+  },
+  {
+    "version": "go1.12.5"
+  },
+  {
+    "version": "go1.12.4"
+  },
+  {
+    "version": "go1.12.3"
+  },
+  {
+    "version": "go1.12.2"
+  },
+  {
+    "version": "go1.12.1"
+  },
+  {
+    "version": "go1.12"
+  },
+  {
+    "version": "go1.12rc1"
+  },
+  {
+    "version": "go1.12beta2"
+  },
+  {
+    "version": "go1.12beta1"
+  },
+  {
+    "version": "go1.11.13"
+  },
+  {
+    "version": "go1.11.12"
+  },
+  {
+    "version": "go1.11.11"
+  },
+  {
+    "version": "go1.11.10"
+  },
+  {
+    "version": "go1.11.9"
+  },
+  {
+    "version": "go1.11.8"
+  },
+  {
+    "version": "go1.11.7"
+  },
+  {
+    "version": "go1.11.6"
+  },
+  {
+    "version": "go1.11.5"
+  },
+  {
+    "version": "go1.11.4"
+  },
+  {
+    "version": "go1.11.3"
+  },
+  {
+    "version": "go1.11.2"
+  },
+  {
+    "version": "go1.11.1"
+  },
+  {
+    "version": "go1.11"
+  },
+  {
+    "version": "go1.11rc2"
+  },
+  {
+    "version": "go1.11rc1"
+  },
+  {
+    "version": "go1.11beta3"
+  },
+  {
+    "version": "go1.11beta2"
+  },
+  {
+    "version": "go1.11beta1"
+  },
+  {
+    "version": "go1.10.8"
+  },
+  {
+    "version": "go1.10.7"
+  },
+  {
+    "version": "go1.10.6"
+  },
+  {
+    "version": "go1.10.5"
+  },
+  {
+    "version": "go1.10.4"
+  },
+  {
+    "version": "go1.10.3"
+  },
+  {
+    "version": "go1.10.2"
+  },
+  {
+    "version": "go1.10.1"
+  },
+  {
+    "version": "go1.10"
+  },
+  {
+    "version": "go1.10rc2"
+  },
+  {
+    "version": "go1.10rc1"
+  },
+  {
+    "version": "go1.10beta2"
+  },
+  {
+    "version": "go1.10beta1"
+  },
+  {
+    "version": "go1.9.7"
+  },
+  {
+    "version": "go1.9.6"
+  },
+  {
+    "version": "go1.9.5"
+  },
+  {
+    "version": "go1.9.4"
+  },
+  {
+    "version": "go1.9.3"
+  },
+  {
+    "version": "go1.9.2"
+  },
+  {
+    "version": "go1.9.2rc2"
+  },
+  {
+    "version": "go1.9.1"
+  },
+  {
+    "version": "go1.9"
+  },
+  {
+    "version": "go1.9rc2"
+  },
+  {
+    "version": "go1.9rc1"
+  },
+  {
+    "version": "go1.9beta2"
+  },
+  {
+    "version": "go1.9beta1"
+  },
+  {
+    "version": "go1.8.7"
+  },
+  {
+    "version": "go1.8.6"
+  },
+  {
+    "version": "go1.8.5"
+  },
+  {
+    "version": "go1.8.5rc4"
+  },
+  {
+    "version": "go1.8.4"
+  },
+  {
+    "version": "go1.8.3"
+  },
+  {
+    "version": "go1.8.2"
+  },
+  {
+    "version": "go1.8.1"
+  },
+  {
+    "version": "go1.8"
+  },
+  {
+    "version": "go1.8rc3"
+  },
+  {
+    "version": "go1.8rc2"
+  },
+  {
+    "version": "go1.8rc1"
+  },
+  {
+    "version": "go1.8beta2"
+  },
+  {
+    "version": "go1.8beta1"
+  },
+  {
+    "version": "go1.7.6"
+  },
+  {
+    "version": "go1.7.5"
+  },
+  {
+    "version": "go1.7.4"
+  },
+  {
+    "version": "go1.7.3"
+  },
+  {
+    "version": "go1.7.1"
+  },
+  {
+    "version": "go1.7"
+  },
+  {
+    "version": "go1.7rc6"
+  },
+  {
+    "version": "go1.7rc5"
+  },
+  {
+    "version": "go1.7rc4"
+  },
+  {
+    "version": "go1.7rc3"
+  },
+  {
+    "version": "go1.7rc2"
+  },
+  {
+    "version": "go1.7rc1"
+  },
+  {
+    "version": "go1.7beta2"
+  },
+  {
+    "version": "go1.7beta1"
+  },
+  {
+    "version": "go1.6.4"
+  },
+  {
+    "version": "go1.6.3"
+  },
+  {
+    "version": "go1.6.2"
+  },
+  {
+    "version": "go1.6.1"
+  },
+  {
+    "version": "go1.6"
+  },
+  {
+    "version": "go1.6rc2"
+  },
+  {
+    "version": "go1.6rc1"
+  },
+  {
+    "version": "go1.6beta2"
+  },
+  {
+    "version": "go1.6beta1"
+  },
+  {
+    "version": "go1.5.4"
+  },
+  {
+    "version": "go1.5.3"
+  },
+  {
+    "version": "go1.5.2"
+  },
+  {
+    "version": "go1.5.1"
+  },
+  {
+    "version": "go1.5"
+  },
+  {
+    "version": "go1.5rc1"
+  },
+  {
+    "version": "go1.5beta3"
+  },
+  {
+    "version": "go1.5beta2"
+  },
+  {
+    "version": "go1.5beta1"
+  },
+  {
+    "version": "go1.4.3"
+  },
+  {
+    "version": "go1.4.2"
+  },
+  {
+    "version": "go1.4.1"
+  },
+  {
+    "version": "go1.4"
+  },
+  {
+    "version": "go1.4rc2"
+  },
+  {
+    "version": "go1.4rc1"
+  },
+  {
+    "version": "go1.4beta1"
+  },
+  {
+    "version": "go1.3.3"
+  },
+  {
+    "version": "go1.3.2"
+  },
+  {
+    "version": "go1.3.1"
+  },
+  {
+    "version": "go1.3"
+  },
+  {
+    "version": "go1.3rc2"
+  },
+  {
+    "version": "go1.3rc1"
+  },
+  {
+    "version": "go1.3beta2"
+  },
+  {
+    "version": "go1.3beta1"
+  },
+  {
+    "version": "go1.2.2"
+  }
+]

--- a/src/testdata/go-dl-stable-sample.json
+++ b/src/testdata/go-dl-stable-sample.json
@@ -1,0 +1,4 @@
+[
+  {"version": "go1.20.7", "stable": true},
+  {"version": "go1.19.12", "stable": true}
+]

--- a/tools/goversion-select/goversion.go
+++ b/tools/goversion-select/goversion.go
@@ -3,7 +3,7 @@
 //
 // Usage:
 //
-//	goversion-select -c <constraint> [--orig] [<candidate>... | -]
+//	goversion-select -c <constraint> [--orig] [--json-input] [<candidate>... | -]
 //
 // Behavior is fixed (no flags to toggle it):
 //   - candidates are always parsed in Go-native format (go1.20, 1.21rc1, ...)
@@ -17,6 +17,17 @@
 //
 // A candidate of "-" means: read remaining candidates from stdin, one per
 // line.
+//
+// With --json-input, stdin is parsed as the JSON array returned by
+// https://go.dev/dl/?mode=json&include=all (objects with a "version"
+// field; other fields are ignored). The decoder runs streaming and exits
+// on the first constraint match, which lets the upstream curl receive
+// SIGPIPE and short-circuit the rest of the transfer. This *assumes
+// upstream returns the array in semver-descending order* — true for
+// go.dev as of writing; if that ever changes, the selected version may
+// not be the highest matching one. Positional candidates may not be
+// combined with --json-input. Building this mode requires
+// GOEXPERIMENT=jsonv2 (Go 1.26 stdlib gates encoding/json/v2 behind it).
 //
 // The underlying model is `version` — a Go release as a numeric (major,
 // minor, patch) triple plus an optional pre-release tag like "rc1". The
@@ -32,6 +43,7 @@ package main
 import (
 	"bufio"
 	"cmp"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -40,6 +52,9 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+
+	"encoding/json/jsontext"
+	json "encoding/json/v2"
 )
 
 func main() {
@@ -51,6 +66,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	constraintFlag := fs.String("c", "", "constraint to match (required)")
 	origFlag := fs.Bool("orig", false, "output the original input string for the top match instead of its canonical form")
+	jsonInputFlag := fs.Bool("json-input", false, "parse stdin as the JSON array returned by https://go.dev/dl/?mode=json&include=all and exit on the first match (stream mode; positional candidates are not allowed)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -62,6 +78,13 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if err != nil {
 		fmt.Fprintf(stderr, "goversion-select: invalid constraint: %q\n", *constraintFlag)
 		return 1
+	}
+	if *jsonInputFlag {
+		if len(fs.Args()) > 0 {
+			fmt.Fprintln(stderr, "goversion-select: --json-input does not accept positional candidates")
+			return 2
+		}
+		return runJSONInput(c, *origFlag, stdin, stdout, stderr)
 	}
 	versions, orig := collectCandidates(fs.Args(), stdin)
 	top, ok := topMatch(c, versions)
@@ -75,6 +98,81 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 0
 	}
 	fmt.Fprintln(stdout, top.String())
+	return 0
+}
+
+// runJSONInput streams the go.dev /dl/?mode=json&include=all payload from
+// stdin and exits on the first constraint match. It relies on the upstream
+// list being semver-descending so that the first match is also the highest
+// match (true for go.dev today; documented in the package comment).
+//
+// Error semantics:
+//   - first match → print and return 0.
+//   - valid array consumed without a match → return 0, no output.
+//   - any decode/IO error before a match (premature EOF, malformed JSON,
+//     non-array root, missing or non-string "version" field, trailing junk
+//     after ']') → return 1 with stderr message. This makes truncated
+//     transfers visible rather than silently masked as "no match".
+func runJSONInput(c constraint, origFlag bool, stdin io.Reader, stdout, stderr io.Writer) int {
+	if stdin == nil {
+		fmt.Fprintln(stderr, "goversion-select: --json-input requires stdin")
+		return 1
+	}
+	dec := jsontext.NewDecoder(stdin)
+	tok, err := dec.ReadToken()
+	if err != nil {
+		fmt.Fprintf(stderr, "goversion-select: --json-input: %v\n", err)
+		return 1
+	}
+	if tok.Kind() != '[' {
+		fmt.Fprintf(stderr, "goversion-select: --json-input: expected JSON array, got %q\n", tok.Kind())
+		return 1
+	}
+	for dec.PeekKind() != ']' {
+		// RejectUnknownMembers is *not* set: go.dev's payload carries
+		// fields beyond "version" (stable, files, ...) that we want to
+		// skip syntactically without allocating.
+		var elt struct {
+			Version *string `json:"version"`
+		}
+		if err := json.UnmarshalDecode(dec, &elt); err != nil {
+			fmt.Fprintf(stderr, "goversion-select: --json-input: %v\n", err)
+			return 1
+		}
+		if elt.Version == nil {
+			fmt.Fprintln(stderr, `goversion-select: --json-input: element missing required "version" field`)
+			return 1
+		}
+		v, err := parseGoVersion(*elt.Version)
+		if err != nil {
+			// Silently skip unparseable values to match the existing
+			// newline-stdin contract — go.dev occasionally exposes
+			// weird tags (e.g. "weekly.*") that the constraint
+			// language wasn't designed to handle.
+			continue
+		}
+		if !c.allows(v) {
+			continue
+		}
+		if origFlag {
+			fmt.Fprintln(stdout, *elt.Version)
+		} else {
+			fmt.Fprintln(stdout, v.String())
+		}
+		return 0
+	}
+	// Consume the closing ']' and verify no trailing junk remains.
+	if _, err := dec.ReadToken(); err != nil {
+		fmt.Fprintf(stderr, "goversion-select: --json-input: %v\n", err)
+		return 1
+	}
+	if _, err := dec.ReadToken(); err != nil && !errors.Is(err, io.EOF) {
+		fmt.Fprintf(stderr, "goversion-select: --json-input: trailing data after JSON array: %v\n", err)
+		return 1
+	} else if err == nil {
+		fmt.Fprintln(stderr, "goversion-select: --json-input: trailing data after JSON array")
+		return 1
+	}
 	return 0
 }
 

--- a/tools/goversion-select/goversion_test.go
+++ b/tools/goversion-select/goversion_test.go
@@ -434,3 +434,196 @@ func Test_run_invalidFlag(t *testing.T) {
 		t.Fatalf("stdout should be empty, got %q", stdout.String())
 	}
 }
+
+// jsonStreamSample is a hand-rolled fixture in go.dev /dl/?mode=json
+// shape — semver-descending, mixed pre-releases and patches, deliberately
+// minimal per object. Tests cover both early matches (latest stable case)
+// and deep matches (older minor cases). Two non-version fields are
+// included on the first object to confirm v2's default ignore-unknown
+// behavior actually skips them.
+const jsonStreamSample = `[
+  {"version":"go1.26.3","stable":true,"files":[]},
+  {"version":"go1.26.2"},
+  {"version":"go1.26.1"},
+  {"version":"go1.26.0"},
+  {"version":"go1.26rc3"},
+  {"version":"go1.25.10"},
+  {"version":"go1.25.9"},
+  {"version":"go1.21.13"},
+  {"version":"go1.21.0"},
+  {"version":"go1.16.15"},
+  {"version":"go1.16beta1"},
+  {"version":"go1.10.8"}
+]`
+
+func Test_run_jsonInput(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		stdin    string
+		wantOut  []string
+		wantExit int
+		wantErr  string // substring expected in stderr
+	}{
+		{
+			name:    "match at index 0",
+			args:    []string{"--json-input", "-c", "1.26.x"},
+			stdin:   jsonStreamSample,
+			wantOut: []string{"1.26.3"},
+		},
+		{
+			name:    "match deep in stream",
+			args:    []string{"--json-input", "-c", "1.10.x"},
+			stdin:   jsonStreamSample,
+			wantOut: []string{"1.10.8"},
+		},
+		{
+			name:    "match mid stream",
+			args:    []string{"--json-input", "-c", "1.21.x"},
+			stdin:   jsonStreamSample,
+			wantOut: []string{"1.21.13"},
+		},
+		{
+			name:    "orig echoes upstream version",
+			args:    []string{"--json-input", "--orig", "-c", "1.26.x"},
+			stdin:   jsonStreamSample,
+			wantOut: []string{"go1.26.3"},
+		},
+		{
+			name:    "star matches highest",
+			args:    []string{"--json-input", "--orig", "-c", "*"},
+			stdin:   jsonStreamSample,
+			wantOut: []string{"go1.26.3"},
+		},
+		{
+			name:    "prerelease exact match",
+			args:    []string{"--json-input", "--orig", "-c", "=1.26.0-rc3"},
+			stdin:   jsonStreamSample,
+			wantOut: []string{"go1.26rc3"},
+		},
+		{
+			name:    "no match returns empty",
+			args:    []string{"--json-input", "-c", "1.99.x"},
+			stdin:   jsonStreamSample,
+			wantOut: nil,
+		},
+		{
+			name:    "empty array no match",
+			args:    []string{"--json-input", "-c", "1.26.x"},
+			stdin:   `[]`,
+			wantOut: nil,
+		},
+		{
+			name:    "skip unparseable version field",
+			args:    []string{"--json-input", "-c", "1.26.x"},
+			stdin:   `[{"version":"weekly.2020-01-01"},{"version":"go1.26.3"}]`,
+			wantOut: []string{"1.26.3"},
+		},
+		{
+			name:     "positional candidate rejected with --json-input",
+			args:     []string{"--json-input", "-c", "1.26.x", "go1.26.3"},
+			stdin:    jsonStreamSample,
+			wantExit: 2,
+			wantErr:  "does not accept positional candidates",
+		},
+		{
+			name:     "missing version field is schema break",
+			args:     []string{"--json-input", "-c", "1.26.x"},
+			stdin:    `[{"stable":true},{"version":"go1.26.3"}]`,
+			wantExit: 1,
+			wantErr:  `missing required "version" field`,
+		},
+		{
+			name:     "null version is schema break",
+			args:     []string{"--json-input", "-c", "1.26.x"},
+			stdin:    `[{"version":null},{"version":"go1.26.3"}]`,
+			wantExit: 1,
+			wantErr:  `missing required "version" field`,
+		},
+		{
+			name:     "non-string version is decode error",
+			args:     []string{"--json-input", "-c", "1.26.x"},
+			stdin:    `[{"version":123}]`,
+			wantExit: 1,
+			wantErr:  "--json-input",
+		},
+		{
+			name:     "non-array root rejected",
+			args:     []string{"--json-input", "-c", "1.26.x"},
+			stdin:    `{"version":"go1.26.3"}`,
+			wantExit: 1,
+			wantErr:  "expected JSON array",
+		},
+		{
+			name:     "malformed JSON before any match",
+			args:     []string{"--json-input", "-c", "1.26.x"},
+			stdin:    `[{"version":"go1.26.3"`,
+			wantExit: 1,
+			wantErr:  "--json-input",
+		},
+		{
+			name:     "truncated array without close bracket",
+			args:     []string{"--json-input", "-c", "1.99.x"},
+			stdin:    `[{"version":"go1.26.3"},{"version":"go1.26.2"}`,
+			wantExit: 1,
+			wantErr:  "--json-input",
+		},
+		{
+			name:     "trailing junk after closing bracket",
+			args:     []string{"--json-input", "-c", "1.99.x"},
+			stdin:    `[{"version":"go1.26.3"}] garbage`,
+			wantExit: 1,
+			wantErr:  "trailing data",
+		},
+		{
+			name:     "empty stdin",
+			args:     []string{"--json-input", "-c", "1.26.x"},
+			stdin:    ``,
+			wantExit: 1,
+			wantErr:  "--json-input",
+		},
+	}
+	for _, td := range cases {
+		t.Run(td.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			exit := run(td.args, strings.NewReader(td.stdin), &stdout, &stderr)
+			if exit != td.wantExit {
+				t.Fatalf("exit: want %d, got %d (stderr=%q stdout=%q)", td.wantExit, exit, stderr.String(), stdout.String())
+			}
+			gotErr := strings.TrimSpace(stderr.String())
+			if td.wantErr == "" {
+				if gotErr != "" {
+					t.Fatalf("stderr: want empty, got %q", gotErr)
+				}
+			} else if !strings.Contains(gotErr, td.wantErr) {
+				t.Fatalf("stderr: want substring %q, got %q", td.wantErr, gotErr)
+			}
+			gotOut := strings.TrimSpace(stdout.String())
+			if len(td.wantOut) == 0 {
+				if gotOut != "" {
+					t.Fatalf("stdout: want empty, got %q", gotOut)
+				}
+				return
+			}
+			gotLines := strings.Split(gotOut, "\n")
+			if !reflect.DeepEqual(gotLines, td.wantOut) {
+				t.Fatalf("stdout: want %v, got %v", td.wantOut, gotLines)
+			}
+		})
+	}
+}
+
+// Test_run_jsonInput_nilStdin covers the explicit nil-stdin guard in
+// runJSONInput. Going through run() requires a non-nil reader (the binary
+// always supplies os.Stdin), so this is a defensive belt-and-suspenders
+// case for callers that bypass run().
+func Test_run_jsonInput_nilStdin(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exit := run([]string{"--json-input", "-c", "1.26.x"}, nil, &stdout, &stderr)
+	if exit != 1 {
+		t.Fatalf("exit: want 1, got %d", exit)
+	}
+	if !strings.Contains(stderr.String(), "requires stdin") {
+		t.Fatalf("stderr: want %q, got %q", "requires stdin", stderr.String())
+	}
+}


### PR DESCRIPTION
Replaces both go-version-resolution paths in the action with direct calls to go.dev's own JSON feed, so the runtime no longer depends on the third-party `WillAbides/goreleases` mirror. Supply-chain-hardening motivated.

## What changes

**Streaming match path** (the cache-miss "pick the highest matching release" leg of `select_remote_version`):

```
curl --compressed 'https://go.dev/dl/?mode=json&include=all' \
  | goversion-select --orig --json-input -c "$constraint"
```

`tools/goversion-select` learns a `--json-input` mode that decodes the array one element at a time with `encoding/json/v2` + `jsontext` (gated behind `GOEXPERIMENT=jsonv2` in Go 1.26.3 — wired into every build site). go.dev returns the array in semver-descending order, so the first match is the highest match; the binary exits as soon as it finds one, curl gets SIGPIPE on the next write, and the TCP transfer short-circuits. Measured wire savings: **40 KB for `1.26.x` (2% of full payload), 120 KB for `1.25.x`, 824 KB for `1.21.x`, 1.8 MB for `1.10.x`**.

**Alias path** (the `stable` / `oldstable` shortcuts):

```
curl --compressed 'https://go.dev/dl/?mode=json' \
  | goversion-select --orig --json-input -c '*'
```

The default `?mode=json` endpoint (no `include=all`) returns just `[latest_stable, latest_oldstable]` in ~23 KB raw / ~5.9 KB gzipped, so the same streaming binary handles it with `-c '*'`.

Both endpoints share a `_fetch_json_url` helper that dispatches `file://` URLs through `cat` (for Windows-MSYS-curl portability and test fixtures) and everything else through `curl -sfL --compressed --retry 4`.

`get_known_versions` and the original `select_remote_version` are left in place — neither has any runtime caller anymore, but no public-surface removal felt necessary in this change.

## Per-file summary

- `tools/goversion-select/goversion.go` — `--json-input` mode using `encoding/json/v2` + `jsontext`.
- `tools/goversion-select/goversion_test.go` — `Test_run_jsonInput` (~18 sub-cases: latest-at-index-0, match-deep-in-stream, no-match exit-1, `--orig` vs canonical, malformed JSON) + `Test_run_jsonInput_nilStdin`.
- `src/lib` — `_fetch_json_url` helper; `select_remote_version_streaming` (new); `get_stable_minor_version` rewritten to take a URL; `resolve_constraint_alias` signature now `(constraint, godev_stable_url)`.
- `src/run` — added `GODEV_JSON_URL` + `GODEV_STABLE_URL` defaults pointing at go.dev. Both are overridable env vars: primary use is tests pointing at file:// fixtures, but they also work as a DR escape hatch for go.dev outages (intentionally not promoted to `action.yml` inputs — keeps the public API surface narrow).
- `src/testdata/go-dl-all-sample.json` — 264-entry fixture mirrored from the pinned goreleases snapshot.
- `src/testdata/go-dl-stable-sample.json` — 2-entry fixture from the same snapshot for alias-path tests.
- `src/lib_test.sh`, `src/run_test_long.sh` — tests use the new fixtures; long tests export `GODEV_*_URL` instead of `VERSIONS_URL`.
- `.github/workflows/script/cross-compile-goversion-select`, `src/goversion-select` — set `GOEXPERIMENT=jsonv2` for every build.
- `.github/workflows/ci.yml`, `script/test-go` (new) — runs the goversion-select Go tests in CI.
- `script/lint` — skips directories so `src/testdata/` doesn't trip shellcheck.

Side effect worth flagging in review: `is_precise_version` now treats a non-empty pre-release suffix (`rc4`, `beta1`) as precise, so post-1.21 Go-native pre-releases short-circuit at `src/run` instead of reaching the streaming function — matches the behavior pre-1.21 pre-releases already had.

## Verification

- CI green across 8 platforms (Linux ubuntu-22/24/slim, macOS 14/15/26/26-intel, Windows 2022/2025) on `3d9ccea`.
- `script/lint` clean.
- `./src/lib_test.sh` — 8 tests OK, including new `test_select_remote_version_streaming` and refreshed `test_resolve_constraint_alias`.
- `./src/run_test_long.sh -- -- test_run_stable test_run_oldstable` — both pass, actually downloading + installing go1.20.7 + go1.19.12 from go.dev.
- Live smoke: `curl 'https://go.dev/dl/?mode=json' | goversion-select --orig --json-input -c '*'` → `go1.26.3` (23 KB payload). `curl --compressed 'https://go.dev/dl/?mode=json&include=all' | goversion-select --orig --json-input -c '1.26.x'` → `go1.26.3` with measurably less than the full ~2 MB transferred.
- Benchmark wall numbers + wire sizes captured on `willabides/benchmark-json-stream` (separate PR onto `test-branch`).

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;